### PR TITLE
Fix showing pending shares from orphaned blocks. 

### DIFF
--- a/src/Miningcore/Persistence/Postgres/Repositories/StatsRepository.cs
+++ b/src/Miningcore/Persistence/Postgres/Repositories/StatsRepository.cs
@@ -87,7 +87,7 @@ public class StatsRepository : IStatsRepository
 
     public async Task<MinerStats> GetMinerStatsAsync(IDbConnection con, IDbTransaction tx, string poolId, string miner, CancellationToken ct)
     {
-        var query = @"SELECT (SELECT SUM(difficulty) FROM shares WHERE poolid = @poolId AND miner = @miner) AS pendingshares,
+        var query = @"SELECT (SELECT SUM(s.difficulty) FROM shares s JOIN blocks b ON s.blockheight = b.blockheight WHERE s.poolid = @poolId AND s.miner = @miner  AND b.status != 'orphaned') AS pendingshares,
             (SELECT amount FROM balances WHERE poolid = @poolId AND address = @miner) AS pendingbalance,
             (SELECT SUM(amount) FROM payments WHERE poolid = @poolId and address = @miner) as totalpaid,
             (SELECT SUM(amount) FROM payments WHERE poolid = @poolId and address = @miner and created >= date_trunc('day', now())) as todaypaid";


### PR DESCRIPTION
May need to be revised later if block.height can get out of sync, since block hash is not stored for some god damn reason. 

This fixes single problem. Miner sees pending shares and comes to complain to pool owner, but the pool owner can not say more than that it's because of orphaned blocks and those shares will not be paid or the pool owner is forced to pay them even though they where orphaned blocks. 

As such removing the shares gained from orphaned blocks is a good way to avoid having this problem with miners.   