### PR TITLE
Add new PPLNSBF payment scheme

### DIFF
--- a/src/Miningcore/AutofacModule.cs
+++ b/src/Miningcore/AutofacModule.cs
@@ -158,7 +158,11 @@ public class AutofacModule : Module
         builder.RegisterType<PPLNSPaymentScheme>()
             .Keyed<IPayoutScheme>(PayoutScheme.PPLNS)
             .SingleInstance();
-
+        
+        builder.RegisterType<PPLNSBFPaymentScheme>()
+            .Keyed<IPayoutScheme>(PayoutScheme.PPLNSBF)
+            .SingleInstance();
+            
         builder.RegisterType<SOLOPaymentScheme>()
             .Keyed<IPayoutScheme>(PayoutScheme.SOLO)
             .SingleInstance();

--- a/src/Miningcore/Configuration/ClusterConfig.cs
+++ b/src/Miningcore/Configuration/ClusterConfig.cs
@@ -680,6 +680,7 @@ public enum PayoutScheme
     SOLO = 3,
     PPS = 4,
     PPBS = 5,
+    PPLNSBF = 6,
 }
 
 public partial class ClusterLoggingConfig

--- a/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
+++ b/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
@@ -18,9 +18,9 @@ namespace Miningcore.Payments.PaymentSchemes;
 /// PPLNSBF payout scheme implementation
 /// </summary>
 // ReSharper disable once InconsistentNaming
-public class PPLNSPaymentScheme : IPayoutScheme
+public class PPLNSBFPaymentScheme : IPayoutScheme
 {
-    public PPLNSPaymentScheme(
+    public PPLNSBFPaymentScheme(
         IConnectionFactory cf,
         IShareRepository shareRepo,
         IBlockRepository blockRepo,
@@ -43,7 +43,7 @@ public class PPLNSPaymentScheme : IPayoutScheme
     private readonly IBlockRepository blockRepo;
     private readonly IConnectionFactory cf;
     private readonly IShareRepository shareRepo;
-    private static readonly ILogger logger = LogManager.GetLogger("PPLNS Payment");
+    private static readonly ILogger logger = LogManager.GetLogger("PPLNSBF Payment");
 
     private const int RetryCount = 4;
     private IAsyncPolicy shareReadFaultPolicy;
@@ -61,7 +61,7 @@ public class PPLNSPaymentScheme : IPayoutScheme
         var poolConfig = pool.Config;
         var payoutConfig = poolConfig.PaymentProcessing.PayoutSchemeConfig;
 
-        // PPLNS window (see https://bitcointalk.org/index.php?topic=39832)
+        // PPLNSBF window (see https://bitcointalk.org/index.php?topic=39832)
         var window = payoutConfig?.ToObject<Config>()?.Factor ?? 2.0m;
 
         // calculate rewards

--- a/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
+++ b/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
@@ -12,255 +12,256 @@ using NLog;
 using Polly;
 using Contract = Miningcore.Contracts.Contract;
 
-namespace Miningcore.Payments.PaymentSchemes
+namespace Miningcore.Payments.PaymentSchemes;
+
+
+/// <summary>
+/// PPLNSBF payout scheme implementation
+/// </summary>
+// ReSharper disable once InconsistentNaming
+public class PPLNSBFPaymentScheme : IPayoutScheme
 {
-    /// <summary>
-    /// PPLNSBF payout scheme implementation
-    /// </summary>
-    // ReSharper disable once InconsistentNaming
-    public class PPLNSBFPaymentScheme : IPayoutScheme
+    public PPLNSBFPaymentScheme(
+        IConnectionFactory cf,
+        IShareRepository shareRepo,
+        IBlockRepository blockRepo,
+        IBalanceRepository balanceRepo)
     {
-        public PPLNSBFPaymentScheme(
-            IConnectionFactory cf,
-            IShareRepository shareRepo,
-            IBlockRepository blockRepo,
-            IBalanceRepository balanceRepo)
-        {
-            Contract.RequiresNonNull(cf);
-            Contract.RequiresNonNull(shareRepo);
-            Contract.RequiresNonNull(blockRepo);
-            Contract.RequiresNonNull(balanceRepo);
+        Contract.RequiresNonNull(cf);
+        Contract.RequiresNonNull(shareRepo);
+        Contract.RequiresNonNull(blockRepo);
+        Contract.RequiresNonNull(balanceRepo);
 
-            this.cf = cf;
-            this.shareRepo = shareRepo;
-            this.blockRepo = blockRepo;
-            this.balanceRepo = balanceRepo;
+        this.cf = cf;
+        this.shareRepo = shareRepo;
+        this.blockRepo = blockRepo;
+        this.balanceRepo = balanceRepo;
 
-            BuildFaultHandlingPolicy();
-        }
+        BuildFaultHandlingPolicy();
+    }
 
-        private readonly IBalanceRepository balanceRepo;
-        private readonly IBlockRepository blockRepo;
-        private readonly IConnectionFactory cf;
-        private readonly IShareRepository shareRepo;
-        private static readonly ILogger logger = LogManager.GetLogger("PPLNSBF Payment");
+    private readonly IBalanceRepository balanceRepo;
+    private readonly IBlockRepository blockRepo;
+    private readonly IConnectionFactory cf;
+    private readonly IShareRepository shareRepo;
+    private static readonly ILogger logger = LogManager.GetLogger("PPLNSBF Payment");
 
-        private const int RetryCount = 4;
-        private IAsyncPolicy shareReadFaultPolicy;
+    private const int RetryCount = 4;
+    private IAsyncPolicy shareReadFaultPolicy;
 
-        private class Config
-        {
-            public decimal Factor { get; set; }
-        }
-
-        #region IPayoutScheme
-
-        public async Task UpdateBalancesAsync(IDbConnection con, IDbTransaction tx, IMiningPool pool, IPayoutHandler payoutHandler,
-            Block block, decimal blockReward, CancellationToken ct)
-        {
-            var poolConfig = pool.Config;
-            var payoutConfig = poolConfig.PaymentProcessing.PayoutSchemeConfig;
-
-            // PPLNSBF window (see https://bitcointalk.org/index.php?topic=39832)
-            var window = payoutConfig?.ToObject<Config>()?.Factor ?? 2.0m;
-
-            // calculate rewards
-            var shares = new Dictionary<string, double>();
-            var rewards = new Dictionary<string, decimal>();
-            var shareCutOffDate = await CalculateRewardsAsync(pool, payoutHandler, window, block, blockReward, shares, rewards, ct);
-
-            // Add block finder reward to rewards with tag "bonus"
-            var blockFinderReward = blockReward * 0.1m; // 10% of block reward
-            var blockFinderAddress = block.Miner;
-            rewards[blockFinderAddress] = blockFinderReward;
-
-            // update balances
-            foreach(var address in rewards.Keys)
-            {
-                var amount = rewards[address];
-                string tag = address == blockFinderAddress ? "bonus" : null; // Set tag as "bonus" for block finder reward
-
-                if(amount > 0)
-                {
-                    logger.Info(() => $"Crediting {address} with {payoutHandler.FormatAmount(amount)} for {FormatUtil.FormatQuantity(shares[address])} ({shares[address]}) shares for block {block.BlockHeight}");
-                    await balanceRepo.AddAmountAsync(con, tx, poolConfig.Id, address, amount, $"Reward for {FormatUtil.FormatQuantity(shares[address])} shares for block {block.BlockHeight}", tag);
-                }
-            }
-
-            // delete discarded shares
-            if(shareCutOffDate.HasValue)
-            {
-                var cutOffCount = await shareRepo.CountSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
-
-                if(cutOffCount > 0)
-                {
-                    await LogDiscardedSharesAsync(ct, poolConfig, block, shareCutOffDate.Value);
-
-                    logger.Info(() => $"Deleting {cutOffCount} discarded shares before {shareCutOffDate.Value:O}");
-                    await shareRepo.DeleteSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
-                }
-            }
-
-            // diagnostics
-            var totalShareCount = shares.Values.ToList().Sum(x => new decimal(x));
-            var totalRewards = rewards.Values.ToList().Sum(x => x);
-
-            if(totalRewards > 0)
-                logger.Info(() => $"{FormatUtil.FormatQuantity((double) totalShareCount)} ({Math.Round(totalShareCount, 2)}) shares contributed to a total payout of {payoutHandler.FormatAmount(totalRewards)} ({totalRewards / blockReward * 100:0.00}% of block reward) to {rewards.Keys.Count} addresses");
-        }
-
-        private async Task LogDiscardedSharesAsync(CancellationToken ct, PoolConfig poolConfig, Block block, DateTime value)
-        {
-            var before = value;
-            var pageSize = 50000;
-            var currentPage = 0;
-            var shares = new Dictionary<string, double>();
-
-            while(true)
-            {
-                logger.Info(() => $"Fetching page {currentPage} of discarded shares for pool {poolConfig.Id}, block {block.BlockHeight}");
-
-                var page = await shareReadFaultPolicy.ExecuteAsync(() =>
-                    cf.Run(con => shareRepo.ReadSharesBeforeAsync(con, poolConfig.Id, before, false, pageSize, ct)));
-
-                currentPage++;
-
-                for(var i = 0; i < page.Length; i++)
-                {
-                    var share = page[i];
-                    var address = share.Miner;
-
-                    // record attributed shares for diagnostic purposes
-                    if(!shares.ContainsKey(address))
-                        shares[address] = share.Difficulty;
-                    else
-                        shares[address] += share.Difficulty;
-                }
-
-                if(page.Length < pageSize)
-                    break;
-
-                before = page[^1].Created;
-            }
-
-            if(shares.Keys.Count > 0)
-            {
-                // sort addresses by shares
-                var addressesByShares = shares.Keys.OrderByDescending(x => shares[x]);
-
-                logger.Info(() => $"{FormatUtil.FormatQuantity(shares.Values.Sum())} ({shares.Values.Sum()}) total discarded shares, block {block.BlockHeight}");
-
-                foreach(var address in addressesByShares)
-                    logger.Info(() => $"{address} = {FormatUtil.FormatQuantity(shares[address])} ({shares[address]}) discarded shares, block {block.BlockHeight}");
-            }
-        }
-
-        #endregion // IPayoutScheme
-
-private async Task<DateTime?> CalculateRewardsAsync(IMiningPool pool, IPayoutHandler payoutHandler, decimal window, Block block, decimal blockReward,
-    Dictionary<string, double> shares, Dictionary<string, decimal> rewards, CancellationToken ct)
-{
-    var poolConfig = pool.Config;
-    var done = false;
-    var before = block.Created;
-    var inclusive = true;
-    var pageSize = 50000;
-    var currentPage = 0;
-    var accumulatedScore = 0.0m;
-    var blockRewardRemaining = blockReward;
-    DateTime? shareCutOffDate = null;
-
-    // Calculate the block finder reward (10% of the block reward)
-    var blockFinderReward = blockReward * 0.1m;
-
-    while (!done && !ct.IsCancellationRequested)
+    private class Config
     {
-        logger.Info(() => $"Fetching page {currentPage} of shares for pool {poolConfig.Id}, block {block.BlockHeight}");
+        public decimal Factor { get; set; }
+    }
 
-        var page = await shareReadFaultPolicy.ExecuteAsync(() =>
-            cf.Run(con => shareRepo.ReadSharesBeforeAsync(con, poolConfig.Id, before, inclusive, pageSize, ct))); //, sw, logger));
+    #region IPayoutScheme
 
-        inclusive = false;
-        currentPage++;
+    public async Task UpdateBalancesAsync(IDbConnection con, IDbTransaction tx, IMiningPool pool, IPayoutHandler payoutHandler,
+        Block block, decimal blockReward, CancellationToken ct)
+    {
+        var poolConfig = pool.Config;
+        var payoutConfig = poolConfig.PaymentProcessing.PayoutSchemeConfig;
 
-        for (var i = 0; !done && i < page.Length; i++)
+        // PPLNSBF window (see https://bitcointalk.org/index.php?topic=39832)
+        var window = payoutConfig?.ToObject<Config>()?.Factor ?? 2.0m;
+
+        // calculate rewards
+        var shares = new Dictionary<string, double>();
+        var rewards = new Dictionary<string, decimal>();
+        var shareCutOffDate = await CalculateRewardsAsync(pool, payoutHandler, window, block, blockReward, shares, rewards, ct);
+
+        // update balances for miner rewards
+        foreach (var address in rewards.Keys)
         {
-            var share = page[i];
+            var amount = rewards[address];
 
-            var address = share.Miner;
-            var shareDiffAdjusted = payoutHandler.AdjustShareDifficulty(share.Difficulty);
-
-            // record attributed shares for diagnostic purposes
-            if (!shares.ContainsKey(address))
-                shares[address] = shareDiffAdjusted;
-            else
-                shares[address] += shareDiffAdjusted;
-
-            var score = (decimal)(shareDiffAdjusted / share.NetworkDifficulty);
-
-            // if accumulated score would cross threshold, cap it to the remaining value
-            if (accumulatedScore + score >= window)
+            if (amount > 0)
             {
-                score = window - accumulatedScore;
-                shareCutOffDate = share.Created;
-                done = true;
+                logger.Info(() => $"Crediting {address} with {payoutHandler.FormatAmount(amount)} for {FormatUtil.FormatQuantity(shares[address])} ({shares[address]}) shares for block {block.BlockHeight}");
+                await balanceRepo.AddAmountAsync(con, tx, poolConfig.Id, address, amount, $"Reward for {FormatUtil.FormatQuantity(shares[address])} shares for block {block.BlockHeight}");
             }
+        }
 
-            // Calculate reward excluding block finder reward
-            var reward = score * (blockReward - blockFinderReward) / window;
-            accumulatedScore += score;
-            blockRewardRemaining -= reward;
+        // Handle block finder reward separately
+        var blockFinderReward = blockReward * 0.1m;
+        var blockFinderAddress = block.Miner;
 
-            // this should never happen
-            if (blockRewardRemaining <= 0 && !done)
-                throw new OverflowException("blockRewardRemaining < 0");
+        logger.Info(() => $"Block finder reward: {payoutHandler.FormatAmount(blockFinderReward)} for block {block.BlockHeight} mined by {blockFinderAddress}");
+        await balanceRepo.AddAmountAsync(con, tx, poolConfig.Id, blockFinderAddress, blockFinderReward, $"Block finder reward for block {block.BlockHeight}");
 
-            if (reward > 0)
+        // delete discarded shares
+        if (shareCutOffDate.HasValue)
+        {
+            var cutOffCount = await shareRepo.CountSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
+
+            if (cutOffCount > 0)
             {
-                // accumulate miner reward
-                if (!rewards.ContainsKey(address))
-                    rewards[address] = reward;
+                await LogDiscardedSharesAsync(ct, poolConfig, block, shareCutOffDate.Value);
+
+                logger.Info(() => $"Deleting {cutOffCount} discarded shares before {shareCutOffDate.Value:O}");
+                await shareRepo.DeleteSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
+            }
+        }
+
+        // diagnostics
+        var totalShareCount = shares.Values.ToList().Sum(x => new decimal(x));
+        var totalRewards = rewards.Values.ToList().Sum(x => x) + blockFinderReward; // Include block finder reward in total rewards
+
+        if (totalRewards > 0)
+            logger.Info(() => $"{FormatUtil.FormatQuantity((double)totalShareCount)} ({Math.Round(totalShareCount, 2)}) shares contributed to a total payout of {payoutHandler.FormatAmount(totalRewards)} ({totalRewards / blockReward * 100:0.00}% of block reward) to {rewards.Keys.Count + 1} addresses");
+    }
+
+    private async Task LogDiscardedSharesAsync(CancellationToken ct, PoolConfig poolConfig, Block block, DateTime value)
+    {
+        var before = value;
+        var pageSize = 50000;
+        var currentPage = 0;
+        var shares = new Dictionary<string, double>();
+
+        while (true)
+        {
+            logger.Info(() => $"Fetching page {currentPage} of discarded shares for pool {poolConfig.Id}, block {block.BlockHeight}");
+
+            var page = await shareReadFaultPolicy.ExecuteAsync(() =>
+                cf.Run(con => shareRepo.ReadSharesBeforeAsync(con, poolConfig.Id, before, false, pageSize, ct)));
+
+            currentPage++;
+
+            for (var i = 0; i < page.Length; i++)
+            {
+                var share = page[i];
+                var address = share.Miner;
+
+                // record attributed shares for diagnostic purposes
+                if (!shares.ContainsKey(address))
+                    shares[address] = share.Difficulty;
                 else
-                    rewards[address] += reward;
+                    shares[address] += share.Difficulty;
             }
+
+            if (page.Length < pageSize)
+                break;
+
+            before = page[^1].Created;
         }
 
-        if (page.Length < pageSize)
-            break;
+        if (shares.Keys.Count > 0)
+        {
+            // sort addresses by shares
+            var addressesByShares = shares.Keys.OrderByDescending(x => shares[x]);
 
-        before = page[^1].Created;
+            logger.Info(() => $"{FormatUtil.FormatQuantity(shares.Values.Sum())} ({shares.Values.Sum()}) total discarded shares, block {block.BlockHeight}");
+
+            foreach (var address in addressesByShares)
+                logger.Info(() => $"{address} = {FormatUtil.FormatQuantity(shares[address])} ({shares[address]}) discarded shares, block {block.BlockHeight}");
+        }
     }
 
-    logger.Info(() => $"Balance-calculation for pool {poolConfig.Id}, block {block.BlockHeight} completed with accumulated score {accumulatedScore:0.####} ({(accumulatedScore / window) * 100:0.#}%)");
-    
-    // Log the block finder reward
-    logger.Info(() => $"Block finder reward: {payoutHandler.FormatAmount(blockFinderReward)} for block {block.BlockHeight} mined by {block.Miner}");
+    #endregion // IPayoutScheme
 
-    // Give block finder reward
-    var blockFinderAddress = block.Miner;
-    if (!rewards.ContainsKey(blockFinderAddress))
-        rewards[blockFinderAddress] = blockFinderReward;
-    else
-        rewards[blockFinderAddress] += blockFinderReward;
+    private async Task<DateTime?> CalculateRewardsAsync(IMiningPool pool, IPayoutHandler payoutHandler, decimal window, Block block, decimal blockReward,
+        Dictionary<string, double> shares, Dictionary<string, decimal> rewards, CancellationToken ct)
+    {
+        var poolConfig = pool.Config;
+        var done = false;
+        var before = block.Created;
+        var inclusive = true;
+        var pageSize = 50000;
+        var currentPage = 0;
+        var accumulatedScore = 0.0m;
+        var blockRewardRemaining = blockReward;
+        DateTime? shareCutOffDate = null;
 
-    return shareCutOffDate;
-}
+        // Calculate the block finder reward (10% of the block reward)
+        var blockFinderReward = blockReward * 0.1m;
 
-
-        private void BuildFaultHandlingPolicy()
+        while (!done && !ct.IsCancellationRequested)
         {
-            var retry = Policy
-                .Handle<DbException>()
-                .Or<SocketException>()
-                .Or<TimeoutException>()
-                .RetryAsync(RetryCount, OnPolicyRetry);
+            logger.Info(() => $"Fetching page {currentPage} of shares for pool {poolConfig.Id}, block {block.BlockHeight}");
 
-            shareReadFaultPolicy = retry;
+            var page = await shareReadFaultPolicy.ExecuteAsync(() =>
+                cf.Run(con => shareRepo.ReadSharesBeforeAsync(con, poolConfig.Id, before, inclusive, pageSize, ct))); //, sw, logger));
+
+            inclusive = false;
+            currentPage++;
+
+            for (var i = 0; !done && i < page.Length; i++)
+            {
+                var share = page[i];
+
+                var address = share.Miner;
+                var shareDiffAdjusted = payoutHandler.AdjustShareDifficulty(share.Difficulty);
+
+                // record attributed shares for diagnostic purposes
+                if (!shares.ContainsKey(address))
+                    shares[address] = shareDiffAdjusted;
+                else
+                    shares[address] += shareDiffAdjusted;
+
+                var score = (decimal)(shareDiffAdjusted / share.NetworkDifficulty);
+
+                // if accumulated score would cross threshold, cap it to the remaining value
+                if (accumulatedScore + score >= window)
+                {
+                    score = window - accumulatedScore;
+                    shareCutOffDate = share.Created;
+                    done = true;
+                }
+
+                // Calculate reward excluding block finder reward
+                var reward = score * (blockReward - blockFinderReward) / window;
+                accumulatedScore += score;
+                blockRewardRemaining -= reward;
+
+                // this should never happen
+                if (blockRewardRemaining <= 0 && !done)
+                    throw new OverflowException("blockRewardRemaining < 0");
+
+                if (reward > 0)
+                {
+                    // accumulate miner reward
+                    if (!rewards.ContainsKey(address))
+                        rewards[address] = reward;
+                    else
+                        rewards[address] += reward;
+                }
+            }
+
+            if (page.Length < pageSize)
+                break;
+
+            before = page[^1].Created;
         }
 
-        private static void OnPolicyRetry(Exception ex, int retry, object context)
-        {
-            logger.Warn(() => $"Retry {retry} due to {ex.Source}: {ex.GetType().Name} ({ex.Message})");
-        }
+        logger.Info(() => $"Balance-calculation for pool {poolConfig.Id}, block {block.BlockHeight} completed with accumulated score {accumulatedScore:0.####} ({(accumulatedScore / window) * 100:0.#}%)");
+
+        // Log the block finder reward
+        logger.Info(() => $"Block finder reward: {payoutHandler.FormatAmount(blockFinderReward)} for block {block.BlockHeight} mined by {block.Miner}");
+
+        // Give block finder reward
+        var blockFinderAddress = block.Miner;
+        if (!rewards.ContainsKey(blockFinderAddress))
+            rewards[blockFinderAddress] = blockFinderReward;
+        else
+            rewards[blockFinderAddress] += blockFinderReward;
+
+        return shareCutOffDate;
+    }
+
+    private void BuildFaultHandlingPolicy()
+    {
+        var retry = Policy
+            .Handle<DbException>()
+            .Or<SocketException>()
+            .Or<TimeoutException>()
+            .RetryAsync(RetryCount, OnPolicyRetry);
+
+        shareReadFaultPolicy = retry;
+    }
+
+    private static void OnPolicyRetry(Exception ex, int retry, object context)
+    {
+        logger.Warn(() => $"Retry {retry} due to {ex.Source}: {ex.GetType().Name} ({ex.Message})");
     }
 }
+

--- a/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
+++ b/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
@@ -226,6 +226,9 @@ public class PPLNSBFPaymentScheme : IPayoutScheme
     }
 
     logger.Info(() => $"Balance-calculation for pool {poolConfig.Id}, block {block.BlockHeight} completed with accumulated score {accumulatedScore:0.####} ({(accumulatedScore / window) * 100:0.#}%)");
+    
+    // Log the block finder reward
+    logger.Info(() => $"Block finder reward: {payoutHandler.FormatAmount(blockFinderReward)} for block {block.BlockHeight} mined by {block.Miner}");
 
     // Give block finder reward
     var blockFinderAddress = block.Miner;

--- a/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
+++ b/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
@@ -62,7 +62,7 @@ public class PPLNSBFPaymentScheme : IPayoutScheme
     var poolConfig = pool.Config;
     var payoutConfig = poolConfig.PaymentProcessing.PayoutSchemeConfig;
 
-    // PPLNSBF window (see https://bitcointalk.org/index.php?topic=39832)
+    // PPLNS window (see https://bitcointalk.org/index.php?topic=39832)
     var window = payoutConfig?.ToObject<Config>()?.Factor ?? 2.0m;
 
     // Calculate the block finder reward (10% of the block reward)

--- a/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
+++ b/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
@@ -1,0 +1,255 @@
+using System.Data;
+using System.Data.Common;
+using System.Net.Sockets;
+using Miningcore.Configuration;
+using Miningcore.Extensions;
+using Miningcore.Mining;
+using Miningcore.Persistence;
+using Miningcore.Persistence.Model;
+using Miningcore.Persistence.Repositories;
+using Miningcore.Util;
+using NLog;
+using Polly;
+using Contract = Miningcore.Contracts.Contract;
+
+namespace Miningcore.Payments.PaymentSchemes;
+
+/// <summary>
+/// PPLNSBF payout scheme implementation
+/// </summary>
+// ReSharper disable once InconsistentNaming
+public class PPLNSPaymentScheme : IPayoutScheme
+{
+    public PPLNSPaymentScheme(
+        IConnectionFactory cf,
+        IShareRepository shareRepo,
+        IBlockRepository blockRepo,
+        IBalanceRepository balanceRepo)
+    {
+        Contract.RequiresNonNull(cf);
+        Contract.RequiresNonNull(shareRepo);
+        Contract.RequiresNonNull(blockRepo);
+        Contract.RequiresNonNull(balanceRepo);
+
+        this.cf = cf;
+        this.shareRepo = shareRepo;
+        this.blockRepo = blockRepo;
+        this.balanceRepo = balanceRepo;
+
+        BuildFaultHandlingPolicy();
+    }
+
+    private readonly IBalanceRepository balanceRepo;
+    private readonly IBlockRepository blockRepo;
+    private readonly IConnectionFactory cf;
+    private readonly IShareRepository shareRepo;
+    private static readonly ILogger logger = LogManager.GetLogger("PPLNS Payment");
+
+    private const int RetryCount = 4;
+    private IAsyncPolicy shareReadFaultPolicy;
+
+    private class Config
+    {
+        public decimal Factor { get; set; }
+    }
+
+    #region IPayoutScheme
+
+    public async Task UpdateBalancesAsync(IDbConnection con, IDbTransaction tx, IMiningPool pool, IPayoutHandler payoutHandler,
+        Block block, decimal blockReward, CancellationToken ct)
+    {
+        var poolConfig = pool.Config;
+        var payoutConfig = poolConfig.PaymentProcessing.PayoutSchemeConfig;
+
+        // PPLNS window (see https://bitcointalk.org/index.php?topic=39832)
+        var window = payoutConfig?.ToObject<Config>()?.Factor ?? 2.0m;
+
+        // calculate rewards
+        var shares = new Dictionary<string, double>();
+        var rewards = new Dictionary<string, decimal>();
+        var shareCutOffDate = await CalculateRewardsAsync(pool, payoutHandler, window, block, blockReward, shares, rewards, ct);
+
+        // update balances
+        foreach(var address in rewards.Keys)
+        {
+            var amount = rewards[address];
+
+            if(amount > 0)
+            {
+                logger.Info(() => $"Crediting {address} with {payoutHandler.FormatAmount(amount)} for {FormatUtil.FormatQuantity(shares[address])} ({shares[address]}) shares for block {block.BlockHeight}");
+                await balanceRepo.AddAmountAsync(con, tx, poolConfig.Id, address, amount, $"Reward for {FormatUtil.FormatQuantity(shares[address])} shares for block {block.BlockHeight}");
+            }
+        }
+
+        // delete discarded shares
+        if(shareCutOffDate.HasValue)
+        {
+            var cutOffCount = await shareRepo.CountSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
+
+            if(cutOffCount > 0)
+            {
+                await LogDiscardedSharesAsync(ct, poolConfig, block, shareCutOffDate.Value);
+
+                logger.Info(() => $"Deleting {cutOffCount} discarded shares before {shareCutOffDate.Value:O}");
+                await shareRepo.DeleteSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
+            }
+        }
+
+        // diagnostics
+        var totalShareCount = shares.Values.ToList().Sum(x => new decimal(x));
+        var totalRewards = rewards.Values.ToList().Sum(x => x);
+
+        if(totalRewards > 0)
+            logger.Info(() => $"{FormatUtil.FormatQuantity((double) totalShareCount)} ({Math.Round(totalShareCount, 2)}) shares contributed to a total payout of {payoutHandler.FormatAmount(totalRewards)} ({totalRewards / blockReward * 100:0.00}% of block reward) to {rewards.Keys.Count} addresses");
+    }
+
+    private async Task LogDiscardedSharesAsync(CancellationToken ct, PoolConfig poolConfig, Block block, DateTime value)
+    {
+        var before = value;
+        var pageSize = 50000;
+        var currentPage = 0;
+        var shares = new Dictionary<string, double>();
+
+        while(true)
+        {
+            logger.Info(() => $"Fetching page {currentPage} of discarded shares for pool {poolConfig.Id}, block {block.BlockHeight}");
+
+            var page = await shareReadFaultPolicy.ExecuteAsync(() =>
+                cf.Run(con => shareRepo.ReadSharesBeforeAsync(con, poolConfig.Id, before, false, pageSize, ct)));
+
+            currentPage++;
+
+            for(var i = 0; i < page.Length; i++)
+            {
+                var share = page[i];
+                var address = share.Miner;
+
+                // record attributed shares for diagnostic purposes
+                if(!shares.ContainsKey(address))
+                    shares[address] = share.Difficulty;
+                else
+                    shares[address] += share.Difficulty;
+            }
+
+            if(page.Length < pageSize)
+                break;
+
+            before = page[^1].Created;
+        }
+
+        if(shares.Keys.Count > 0)
+        {
+            // sort addresses by shares
+            var addressesByShares = shares.Keys.OrderByDescending(x => shares[x]);
+
+            logger.Info(() => $"{FormatUtil.FormatQuantity(shares.Values.Sum())} ({shares.Values.Sum()}) total discarded shares, block {block.BlockHeight}");
+
+            foreach(var address in addressesByShares)
+                logger.Info(() => $"{address} = {FormatUtil.FormatQuantity(shares[address])} ({shares[address]}) discarded shares, block {block.BlockHeight}");
+        }
+    }
+
+    #endregion // IPayoutScheme
+
+ private async Task<DateTime?> CalculateRewardsAsync(IMiningPool pool, IPayoutHandler payoutHandler, decimal window, Block block, decimal blockReward,
+    Dictionary<string, double> shares, Dictionary<string, decimal> rewards, CancellationToken ct)
+{
+    var poolConfig = pool.Config;
+    var done = false;
+    var before = block.Created;
+    var inclusive = true;
+    var pageSize = 50000;
+    var currentPage = 0;
+    var accumulatedScore = 0.0m;
+    var blockRewardRemaining = blockReward;
+    DateTime? shareCutOffDate = null;
+
+    // Calculate the block finder reward (10% of the block reward)
+    var blockFinderReward = blockReward * 0.1m;
+
+    while (!done && !ct.IsCancellationRequested)
+    {
+        logger.Info(() => $"Fetching page {currentPage} of shares for pool {poolConfig.Id}, block {block.BlockHeight}");
+
+        var page = await shareReadFaultPolicy.ExecuteAsync(() =>
+            cf.Run(con => shareRepo.ReadSharesBeforeAsync(con, poolConfig.Id, before, inclusive, pageSize, ct))); //, sw, logger));
+
+        inclusive = false;
+        currentPage++;
+
+        for (var i = 0; !done && i < page.Length; i++)
+        {
+            var share = page[i];
+
+            var address = share.Miner;
+            var shareDiffAdjusted = payoutHandler.AdjustShareDifficulty(share.Difficulty);
+
+            // record attributed shares for diagnostic purposes
+            if (!shares.ContainsKey(address))
+                shares[address] = shareDiffAdjusted;
+            else
+                shares[address] += shareDiffAdjusted;
+
+            var score = (decimal)(shareDiffAdjusted / share.NetworkDifficulty);
+
+            // if accumulated score would cross threshold, cap it to the remaining value
+            if (accumulatedScore + score >= window)
+            {
+                score = window - accumulatedScore;
+                shareCutOffDate = share.Created;
+                done = true;
+            }
+
+            // Calculate reward excluding block finder reward
+            var reward = score * (blockReward - blockFinderReward) / window;
+            accumulatedScore += score;
+            blockRewardRemaining -= reward;
+
+            // this should never happen
+            if (blockRewardRemaining <= 0 && !done)
+                throw new OverflowException("blockRewardRemaining < 0");
+
+            if (reward > 0)
+            {
+                // accumulate miner reward
+                if (!rewards.ContainsKey(address))
+                    rewards[address] = reward;
+                else
+                    rewards[address] += reward;
+            }
+        }
+
+        if (page.Length < pageSize)
+            break;
+
+        before = page[^1].Created;
+    }
+
+    logger.Info(() => $"Balance-calculation for pool {poolConfig.Id}, block {block.BlockHeight} completed with accumulated score {accumulatedScore:0.####} ({(accumulatedScore / window) * 100:0.#}%)");
+
+    // Give block finder reward
+    var blockFinderAddress = block.Miner;
+    if (!rewards.ContainsKey(blockFinderAddress))
+        rewards[blockFinderAddress] = blockFinderReward;
+    else
+        rewards[blockFinderAddress] += blockFinderReward;
+
+    return shareCutOffDate;
+}
+
+    private void BuildFaultHandlingPolicy()
+    {
+        var retry = Policy
+            .Handle<DbException>()
+            .Or<SocketException>()
+            .Or<TimeoutException>()
+            .RetryAsync(RetryCount, OnPolicyRetry);
+
+        shareReadFaultPolicy = retry;
+    }
+
+    private static void OnPolicyRetry(Exception ex, int retry, object context)
+    {
+        logger.Warn(() => $"Retry {retry} due to {ex.Source}: {ex.GetType().Name} ({ex.Message})");
+    }
+}

--- a/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
+++ b/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
@@ -56,60 +56,68 @@ public class PPLNSBFPaymentScheme : IPayoutScheme
 
     #region IPayoutScheme
 
-    public async Task UpdateBalancesAsync(IDbConnection con, IDbTransaction tx, IMiningPool pool, IPayoutHandler payoutHandler,
-        Block block, decimal blockReward, CancellationToken ct)
+ public async Task UpdateBalancesAsync(IDbConnection con, IDbTransaction tx, IMiningPool pool, IPayoutHandler payoutHandler,
+    Block block, decimal blockReward, CancellationToken ct)
+{
+    var poolConfig = pool.Config;
+    var payoutConfig = poolConfig.PaymentProcessing.PayoutSchemeConfig;
+
+    // PPLNSBF window (see https://bitcointalk.org/index.php?topic=39832)
+    var window = payoutConfig?.ToObject<Config>()?.Factor ?? 2.0m;
+
+    // Calculate the block finder reward (10% of the block reward)
+    var blockFinderReward = blockReward * 0.1m;
+
+    // Calculate the total reward for miners (excluding block finder reward)
+    var totalRewardForMiners = blockReward - blockFinderReward;
+
+    // calculate rewards
+    var shares = new Dictionary<string, double>();
+    var rewards = new Dictionary<string, decimal>();
+    var shareCutOffDate = await CalculateRewardsAsync(pool, payoutHandler, window, block, totalRewardForMiners, shares, rewards, ct);
+
+    // Update balances for miner rewards
+    foreach (var address in rewards.Keys)
     {
-        var poolConfig = pool.Config;
-        var payoutConfig = poolConfig.PaymentProcessing.PayoutSchemeConfig;
+        var amount = rewards[address];
 
-        // PPLNSBF window (see https://bitcointalk.org/index.php?topic=39832)
-        var window = payoutConfig?.ToObject<Config>()?.Factor ?? 2.0m;
-
-        // calculate rewards
-        var shares = new Dictionary<string, double>();
-        var rewards = new Dictionary<string, decimal>();
-        var shareCutOffDate = await CalculateRewardsAsync(pool, payoutHandler, window, block, blockReward, shares, rewards, ct);
-
-        // update balances for miner rewards
-        foreach (var address in rewards.Keys)
+        if (amount > 0)
         {
-            var amount = rewards[address];
-
-            if (amount > 0)
-            {
-                logger.Info(() => $"Crediting {address} with {payoutHandler.FormatAmount(amount)} for {FormatUtil.FormatQuantity(shares[address])} ({shares[address]}) shares for block {block.BlockHeight}");
-                await balanceRepo.AddAmountAsync(con, tx, poolConfig.Id, address, amount, $"Reward for {FormatUtil.FormatQuantity(shares[address])} shares for block {block.BlockHeight}");
-            }
+            logger.Info(() => $"Crediting {address} with {payoutHandler.FormatAmount(amount)} for {FormatUtil.FormatQuantity(shares[address])} ({shares[address]}) shares for block {block.BlockHeight}");
+            await balanceRepo.AddAmountAsync(con, tx, poolConfig.Id, address, amount, $"Reward for {FormatUtil.FormatQuantity(shares[address])} shares for block {block.BlockHeight}");
         }
-
-        // Handle block finder reward separately
-        var blockFinderReward = blockReward * 0.1m;
-        var blockFinderAddress = block.Miner;
-
-        logger.Info(() => $"Block finder reward: {payoutHandler.FormatAmount(blockFinderReward)} for block {block.BlockHeight} mined by {blockFinderAddress}");
-        await balanceRepo.AddAmountAsync(con, tx, poolConfig.Id, blockFinderAddress, blockFinderReward, $"Block finder reward for block {block.BlockHeight}");
-
-        // delete discarded shares
-        if (shareCutOffDate.HasValue)
-        {
-            var cutOffCount = await shareRepo.CountSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
-
-            if (cutOffCount > 0)
-            {
-                await LogDiscardedSharesAsync(ct, poolConfig, block, shareCutOffDate.Value);
-
-                logger.Info(() => $"Deleting {cutOffCount} discarded shares before {shareCutOffDate.Value:O}");
-                await shareRepo.DeleteSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
-            }
-        }
-
-        // diagnostics
-        var totalShareCount = shares.Values.ToList().Sum(x => new decimal(x));
-        var totalRewards = rewards.Values.ToList().Sum(x => x) + blockFinderReward; // Include block finder reward in total rewards
-
-        if (totalRewards > 0)
-            logger.Info(() => $"{FormatUtil.FormatQuantity((double)totalShareCount)} ({Math.Round(totalShareCount, 2)}) shares contributed to a total payout of {payoutHandler.FormatAmount(totalRewards)} ({totalRewards / blockReward * 100:0.00}% of block reward) to {rewards.Keys.Count + 1} addresses");
     }
+
+    // Handle block finder reward separately
+    logger.Info(() => $"Block finder reward: {payoutHandler.FormatAmount(blockFinderReward)} for block {block.BlockHeight} mined by {block.Miner}");
+    await balanceRepo.AddAmountAsync(con, tx, poolConfig.Id, block.Miner, blockFinderReward, $"Block finder reward for block {block.BlockHeight}");
+
+    // Delete discarded shares
+    if (shareCutOffDate.HasValue)
+    {
+        var cutOffCount = await shareRepo.CountSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
+
+        if (cutOffCount > 0)
+        {
+            await LogDiscardedSharesAsync(ct, poolConfig, block, shareCutOffDate.Value);
+
+            logger.Info(() => $"Deleting {cutOffCount} discarded shares before {shareCutOffDate.Value:O}");
+            await shareRepo.DeleteSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
+        }
+    }
+
+ // Diagnostics
+var totalShareCount = shares.Values.ToList().Sum(x => new decimal(x));
+var totalRewards = rewards.Values.ToList().Sum(x => x); // Total rewards distributed to miners
+
+// Add the block finder reward to the total rewards
+totalRewards += blockFinderReward;
+
+if (totalRewards > 0)
+    logger.Info(() => $"{FormatUtil.FormatQuantity((double)totalShareCount)} ({Math.Round(totalShareCount, 2)}) shares contributed to a total payout of {payoutHandler.FormatAmount(totalRewards)} ({totalRewards / totalRewardForMiners * 100:0.00}% of block reward) to {rewards.Keys.Count + 1} addresses");
+
+ }
+
 
     private async Task LogDiscardedSharesAsync(CancellationToken ct, PoolConfig poolConfig, Block block, DateTime value)
     {

--- a/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
+++ b/src/Miningcore/Payments/PaymentSchemes/PPLNSBFPaymentScheme.cs
@@ -12,247 +12,244 @@ using NLog;
 using Polly;
 using Contract = Miningcore.Contracts.Contract;
 
-namespace Miningcore.Payments.PaymentSchemes;
-
-/// <summary>
-/// PPLNSBF payout scheme implementation
-/// </summary>
-// ReSharper disable once InconsistentNaming
-public class PPLNSBFPaymentScheme : IPayoutScheme
+namespace Miningcore.Payments.PaymentSchemes
 {
-    public PPLNSBFPaymentScheme(
-        IConnectionFactory cf,
-        IShareRepository shareRepo,
-        IBlockRepository blockRepo,
-        IBalanceRepository balanceRepo)
+    /// <summary>
+    /// PPLNSBF payout scheme implementation
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public class PPLNSBFPaymentScheme : IPayoutScheme
     {
-        Contract.RequiresNonNull(cf);
-        Contract.RequiresNonNull(shareRepo);
-        Contract.RequiresNonNull(blockRepo);
-        Contract.RequiresNonNull(balanceRepo);
-
-        this.cf = cf;
-        this.shareRepo = shareRepo;
-        this.blockRepo = blockRepo;
-        this.balanceRepo = balanceRepo;
-
-        BuildFaultHandlingPolicy();
-    }
-
-    private readonly IBalanceRepository balanceRepo;
-    private readonly IBlockRepository blockRepo;
-    private readonly IConnectionFactory cf;
-    private readonly IShareRepository shareRepo;
-    private static readonly ILogger logger = LogManager.GetLogger("PPLNSBF Payment");
-
-    private const int RetryCount = 4;
-    private IAsyncPolicy shareReadFaultPolicy;
-
-    private class Config
-    {
-        public decimal Factor { get; set; }
-    }
-
-    #region IPayoutScheme
-
-    public async Task UpdateBalancesAsync(IDbConnection con, IDbTransaction tx, IMiningPool pool, IPayoutHandler payoutHandler,
-        Block block, decimal blockReward, CancellationToken ct)
-    {
-        var poolConfig = pool.Config;
-        var payoutConfig = poolConfig.PaymentProcessing.PayoutSchemeConfig;
-
-        // PPLNSBF window (see https://bitcointalk.org/index.php?topic=39832)
-        var window = payoutConfig?.ToObject<Config>()?.Factor ?? 2.0m;
-
-        // calculate rewards
-        var shares = new Dictionary<string, double>();
-        var rewards = new Dictionary<string, decimal>();
-        var shareCutOffDate = await CalculateRewardsAsync(pool, payoutHandler, window, block, blockReward, shares, rewards, ct);
-
-        // update balances
-        foreach(var address in rewards.Keys)
+        public PPLNSBFPaymentScheme(
+            IConnectionFactory cf,
+            IShareRepository shareRepo,
+            IBlockRepository blockRepo,
+            IBalanceRepository balanceRepo)
         {
-            var amount = rewards[address];
+            Contract.RequiresNonNull(cf);
+            Contract.RequiresNonNull(shareRepo);
+            Contract.RequiresNonNull(blockRepo);
+            Contract.RequiresNonNull(balanceRepo);
 
-            if(amount > 0)
+            this.cf = cf;
+            this.shareRepo = shareRepo;
+            this.blockRepo = blockRepo;
+            this.balanceRepo = balanceRepo;
+
+            BuildFaultHandlingPolicy();
+        }
+
+        private readonly IBalanceRepository balanceRepo;
+        private readonly IBlockRepository blockRepo;
+        private readonly IConnectionFactory cf;
+        private readonly IShareRepository shareRepo;
+        private static readonly ILogger logger = LogManager.GetLogger("PPLNSBF Payment");
+
+        private const int RetryCount = 4;
+        private IAsyncPolicy shareReadFaultPolicy;
+
+        private class Config
+        {
+            public decimal Factor { get; set; }
+        }
+
+        #region IPayoutScheme
+
+        public async Task UpdateBalancesAsync(IDbConnection con, IDbTransaction tx, IMiningPool pool, IPayoutHandler payoutHandler,
+            Block block, decimal blockReward, CancellationToken ct)
+        {
+            var poolConfig = pool.Config;
+            var payoutConfig = poolConfig.PaymentProcessing.PayoutSchemeConfig;
+
+            // PPLNSBF window (see https://bitcointalk.org/index.php?topic=39832)
+            var window = payoutConfig?.ToObject<Config>()?.Factor ?? 2.0m;
+
+            // calculate rewards
+            var shares = new Dictionary<string, double>();
+            var rewards = new Dictionary<string, decimal>();
+            var shareCutOffDate = await CalculateRewardsAsync(pool, payoutHandler, window, block, blockReward, shares, rewards, ct);
+
+            // Add block finder reward to rewards with tag "bonus"
+            var blockFinderReward = blockReward * 0.1m; // 10% of block reward
+            var blockFinderAddress = block.Miner;
+            rewards[blockFinderAddress] = blockFinderReward;
+
+            // update balances
+            foreach(var address in rewards.Keys)
             {
-                logger.Info(() => $"Crediting {address} with {payoutHandler.FormatAmount(amount)} for {FormatUtil.FormatQuantity(shares[address])} ({shares[address]}) shares for block {block.BlockHeight}");
-                await balanceRepo.AddAmountAsync(con, tx, poolConfig.Id, address, amount, $"Reward for {FormatUtil.FormatQuantity(shares[address])} shares for block {block.BlockHeight}");
+                var amount = rewards[address];
+                string tag = address == blockFinderAddress ? "bonus" : null; // Set tag as "bonus" for block finder reward
+
+                if(amount > 0)
+                {
+                    logger.Info(() => $"Crediting {address} with {payoutHandler.FormatAmount(amount)} for {FormatUtil.FormatQuantity(shares[address])} ({shares[address]}) shares for block {block.BlockHeight}");
+                    await balanceRepo.AddAmountAsync(con, tx, poolConfig.Id, address, amount, $"Reward for {FormatUtil.FormatQuantity(shares[address])} shares for block {block.BlockHeight}", tag);
+                }
+            }
+
+            // delete discarded shares
+            if(shareCutOffDate.HasValue)
+            {
+                var cutOffCount = await shareRepo.CountSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
+
+                if(cutOffCount > 0)
+                {
+                    await LogDiscardedSharesAsync(ct, poolConfig, block, shareCutOffDate.Value);
+
+                    logger.Info(() => $"Deleting {cutOffCount} discarded shares before {shareCutOffDate.Value:O}");
+                    await shareRepo.DeleteSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
+                }
+            }
+
+            // diagnostics
+            var totalShareCount = shares.Values.ToList().Sum(x => new decimal(x));
+            var totalRewards = rewards.Values.ToList().Sum(x => x);
+
+            if(totalRewards > 0)
+                logger.Info(() => $"{FormatUtil.FormatQuantity((double) totalShareCount)} ({Math.Round(totalShareCount, 2)}) shares contributed to a total payout of {payoutHandler.FormatAmount(totalRewards)} ({totalRewards / blockReward * 100:0.00}% of block reward) to {rewards.Keys.Count} addresses");
+        }
+
+        private async Task LogDiscardedSharesAsync(CancellationToken ct, PoolConfig poolConfig, Block block, DateTime value)
+        {
+            var before = value;
+            var pageSize = 50000;
+            var currentPage = 0;
+            var shares = new Dictionary<string, double>();
+
+            while(true)
+            {
+                logger.Info(() => $"Fetching page {currentPage} of discarded shares for pool {poolConfig.Id}, block {block.BlockHeight}");
+
+                var page = await shareReadFaultPolicy.ExecuteAsync(() =>
+                    cf.Run(con => shareRepo.ReadSharesBeforeAsync(con, poolConfig.Id, before, false, pageSize, ct)));
+
+                currentPage++;
+
+                for(var i = 0; i < page.Length; i++)
+                {
+                    var share = page[i];
+                    var address = share.Miner;
+
+                    // record attributed shares for diagnostic purposes
+                    if(!shares.ContainsKey(address))
+                        shares[address] = share.Difficulty;
+                    else
+                        shares[address] += share.Difficulty;
+                }
+
+                if(page.Length < pageSize)
+                    break;
+
+                before = page[^1].Created;
+            }
+
+            if(shares.Keys.Count > 0)
+            {
+                // sort addresses by shares
+                var addressesByShares = shares.Keys.OrderByDescending(x => shares[x]);
+
+                logger.Info(() => $"{FormatUtil.FormatQuantity(shares.Values.Sum())} ({shares.Values.Sum()}) total discarded shares, block {block.BlockHeight}");
+
+                foreach(var address in addressesByShares)
+                    logger.Info(() => $"{address} = {FormatUtil.FormatQuantity(shares[address])} ({shares[address]}) discarded shares, block {block.BlockHeight}");
             }
         }
 
-        // delete discarded shares
-        if(shareCutOffDate.HasValue)
-        {
-            var cutOffCount = await shareRepo.CountSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
+        #endregion // IPayoutScheme
 
-            if(cutOffCount > 0)
+        private async Task<DateTime?> CalculateRewardsAsync(IMiningPool pool, IPayoutHandler payoutHandler, decimal window, Block block, decimal blockReward,
+            Dictionary<string, double> shares, Dictionary<string, decimal> rewards, CancellationToken ct)
+        {
+            var poolConfig = pool.Config;
+            var done = false;
+            var before = block.Created;
+            var inclusive = true;
+            var pageSize = 50000;
+            var currentPage = 0;
+            var accumulatedScore = 0.0m;
+            var blockRewardRemaining = blockReward;
+            DateTime? shareCutOffDate = null;
+
+            while (!done && !ct.IsCancellationRequested)
             {
-                await LogDiscardedSharesAsync(ct, poolConfig, block, shareCutOffDate.Value);
+                logger.Info(() => $"Fetching page {currentPage} of shares for pool {poolConfig.Id}, block {block.BlockHeight}");
 
-                logger.Info(() => $"Deleting {cutOffCount} discarded shares before {shareCutOffDate.Value:O}");
-                await shareRepo.DeleteSharesBeforeAsync(con, tx, poolConfig.Id, shareCutOffDate.Value, ct);
-            }
-        }
+                var page = await shareReadFaultPolicy.ExecuteAsync(() =>
+                    cf.Run(con => shareRepo.ReadSharesBeforeAsync(con, poolConfig.Id, before, inclusive, pageSize, ct))); //, sw, logger));
 
-        // diagnostics
-        var totalShareCount = shares.Values.ToList().Sum(x => new decimal(x));
-        var totalRewards = rewards.Values.ToList().Sum(x => x);
+                inclusive = false;
+                currentPage++;
 
-        if(totalRewards > 0)
-            logger.Info(() => $"{FormatUtil.FormatQuantity((double) totalShareCount)} ({Math.Round(totalShareCount, 2)}) shares contributed to a total payout of {payoutHandler.FormatAmount(totalRewards)} ({totalRewards / blockReward * 100:0.00}% of block reward) to {rewards.Keys.Count} addresses");
-    }
+                for (var i = 0; !done && i < page.Length; i++)
+                {
+                    var share = page[i];
 
-    private async Task LogDiscardedSharesAsync(CancellationToken ct, PoolConfig poolConfig, Block block, DateTime value)
-    {
-        var before = value;
-        var pageSize = 50000;
-        var currentPage = 0;
-        var shares = new Dictionary<string, double>();
+                    var address = share.Miner;
+                    var shareDiffAdjusted = payoutHandler.AdjustShareDifficulty(share.Difficulty);
 
-        while(true)
-        {
-            logger.Info(() => $"Fetching page {currentPage} of discarded shares for pool {poolConfig.Id}, block {block.BlockHeight}");
+                    // record attributed shares for diagnostic purposes
+                    if (!shares.ContainsKey(address))
+                        shares[address] = shareDiffAdjusted;
+                    else
+                        shares[address] += shareDiffAdjusted;
 
-            var page = await shareReadFaultPolicy.ExecuteAsync(() =>
-                cf.Run(con => shareRepo.ReadSharesBeforeAsync(con, poolConfig.Id, before, false, pageSize, ct)));
+                    var score = (decimal)(shareDiffAdjusted / share.NetworkDifficulty);
 
-            currentPage++;
+                    // if accumulated score would cross threshold, cap it to the remaining value
+                    if (accumulatedScore + score >= window)
+                    {
+                        score = window - accumulatedScore;
+                        shareCutOffDate = share.Created;
+                        done = true;
+                    }
 
-            for(var i = 0; i < page.Length; i++)
-            {
-                var share = page[i];
-                var address = share.Miner;
+                    // Calculate reward excluding block finder reward
+                    var reward = score * (blockReward - blockFinderReward) / window;
+                    accumulatedScore += score;
+                    blockRewardRemaining -= reward;
 
-                // record attributed shares for diagnostic purposes
-                if(!shares.ContainsKey(address))
-                    shares[address] = share.Difficulty;
-                else
-                    shares[address] += share.Difficulty;
-            }
+                    // this should never happen
+                    if (blockRewardRemaining <= 0 && !done)
+                        throw new OverflowException("blockRewardRemaining < 0");
 
-            if(page.Length < pageSize)
-                break;
+                    if (reward > 0)
+                    {
+                        // accumulate miner reward
+                        if (!rewards.ContainsKey(address))
+                            rewards[address] = reward;
+                        else
+                            rewards[address] += reward;
+                    }
+                }
 
-            before = page[^1].Created;
-        }
+                if (page.Length < pageSize)
+                    break;
 
-        if(shares.Keys.Count > 0)
-        {
-            // sort addresses by shares
-            var addressesByShares = shares.Keys.OrderByDescending(x => shares[x]);
-
-            logger.Info(() => $"{FormatUtil.FormatQuantity(shares.Values.Sum())} ({shares.Values.Sum()}) total discarded shares, block {block.BlockHeight}");
-
-            foreach(var address in addressesByShares)
-                logger.Info(() => $"{address} = {FormatUtil.FormatQuantity(shares[address])} ({shares[address]}) discarded shares, block {block.BlockHeight}");
-        }
-    }
-
-    #endregion // IPayoutScheme
-
- private async Task<DateTime?> CalculateRewardsAsync(IMiningPool pool, IPayoutHandler payoutHandler, decimal window, Block block, decimal blockReward,
-    Dictionary<string, double> shares, Dictionary<string, decimal> rewards, CancellationToken ct)
-{
-    var poolConfig = pool.Config;
-    var done = false;
-    var before = block.Created;
-    var inclusive = true;
-    var pageSize = 50000;
-    var currentPage = 0;
-    var accumulatedScore = 0.0m;
-    var blockRewardRemaining = blockReward;
-    DateTime? shareCutOffDate = null;
-
-    // Calculate the block finder reward (10% of the block reward)
-    var blockFinderReward = blockReward * 0.1m;
-
-    while (!done && !ct.IsCancellationRequested)
-    {
-        logger.Info(() => $"Fetching page {currentPage} of shares for pool {poolConfig.Id}, block {block.BlockHeight}");
-
-        var page = await shareReadFaultPolicy.ExecuteAsync(() =>
-            cf.Run(con => shareRepo.ReadSharesBeforeAsync(con, poolConfig.Id, before, inclusive, pageSize, ct))); //, sw, logger));
-
-        inclusive = false;
-        currentPage++;
-
-        for (var i = 0; !done && i < page.Length; i++)
-        {
-            var share = page[i];
-
-            var address = share.Miner;
-            var shareDiffAdjusted = payoutHandler.AdjustShareDifficulty(share.Difficulty);
-
-            // record attributed shares for diagnostic purposes
-            if (!shares.ContainsKey(address))
-                shares[address] = shareDiffAdjusted;
-            else
-                shares[address] += shareDiffAdjusted;
-
-            var score = (decimal)(shareDiffAdjusted / share.NetworkDifficulty);
-
-            // if accumulated score would cross threshold, cap it to the remaining value
-            if (accumulatedScore + score >= window)
-            {
-                score = window - accumulatedScore;
-                shareCutOffDate = share.Created;
-                done = true;
+                before = page[^1].Created;
             }
 
-            // Calculate reward excluding block finder reward
-            var reward = score * (blockReward - blockFinderReward) / window;
-            accumulatedScore += score;
-            blockRewardRemaining -= reward;
+            logger.Info(() => $"Balance-calculation for pool {poolConfig.Id}, block {block.BlockHeight} completed with accumulated score {accumulatedScore:0.####} ({(accumulatedScore / window) * 100:0.#}%)");
+            
+            // Log the block finder reward
+            logger.Info(() => $"Block finder reward: {payoutHandler.FormatAmount(blockFinderReward)} for block {block.BlockHeight} mined by {block.Miner}");
 
-            // this should never happen
-            if (blockRewardRemaining <= 0 && !done)
-                throw new OverflowException("blockRewardRemaining < 0");
-
-            if (reward > 0)
-            {
-                // accumulate miner reward
-                if (!rewards.ContainsKey(address))
-                    rewards[address] = reward;
-                else
-                    rewards[address] += reward;
-            }
+            return shareCutOffDate;
         }
 
-        if (page.Length < pageSize)
-            break;
+        private void BuildFaultHandlingPolicy()
+        {
+            var retry = Policy
+                .Handle<DbException>()
+                .Or<SocketException>()
+                .Or<TimeoutException>()
+                .RetryAsync(RetryCount, OnPolicyRetry);
 
-        before = page[^1].Created;
-    }
+            shareReadFaultPolicy = retry;
+        }
 
-    logger.Info(() => $"Balance-calculation for pool {poolConfig.Id}, block {block.BlockHeight} completed with accumulated score {accumulatedScore:0.####} ({(accumulatedScore / window) * 100:0.#}%)");
-    
-    // Log the block finder reward
-    logger.Info(() => $"Block finder reward: {payoutHandler.FormatAmount(blockFinderReward)} for block {block.BlockHeight} mined by {block.Miner}");
-
-    // Give block finder reward
-    var blockFinderAddress = block.Miner;
-    if (!rewards.ContainsKey(blockFinderAddress))
-        rewards[blockFinderAddress] = blockFinderReward;
-    else
-        rewards[blockFinderAddress] += blockFinderReward;
-
-    return shareCutOffDate;
-}
-
-    private void BuildFaultHandlingPolicy()
-    {
-        var retry = Policy
-            .Handle<DbException>()
-            .Or<SocketException>()
-            .Or<TimeoutException>()
-            .RetryAsync(RetryCount, OnPolicyRetry);
-
-        shareReadFaultPolicy = retry;
-    }
-
-    private static void OnPolicyRetry(Exception ex, int retry, object context)
-    {
-        logger.Warn(() => $"Retry {retry} due to {ex.Source}: {ex.GetType().Name} ({ex.Message})");
+        private static void OnPolicyRetry(Exception ex, int retry, object context)
+        {
+            logger.Warn(() => $"Retry {retry} due to {ex.Source}: {ex.GetType().Name} ({ex.Message})");
+        }
     }
 }

--- a/src/Miningcore/config.schema.json
+++ b/src/Miningcore/config.schema.json
@@ -531,6 +531,7 @@
           "type": "string",
           "enum": [
             "PPLNS",
+            "PPLNSBF",
             "PROP",
             "SOLO",
             "PPS",


### PR DESCRIPTION
- Gives 10% of the block value to the block finder. The value is calculated after the pool fee is deducted.
- The rest is split between the other miners using normal PPLNS.

This is en example of how the info is logged into the database:
![image](https://github.com/megabrr/miningcore/assets/151932886/7e19f3d3-a1e4-4fc8-b298-b95167500f11)

As you can see the block value for this project is 440. The pool fee was set to 0.5%.
Block 2711223
Pool fee: 440 * 0.5% = 2.2
Block finder reward: (440-2.2) * 10% = 43.78
226.66 (miner 1 shares) + 167.36  (miner 2 shares) + 43.78 (block finder reward) + 2.2 (pool fee) = 440
