### PR TITLE
Change Fixed Diff to Starting Diff

### DIFF
--- a/src/Miningcore/Api/Responses/GetPoolsResponse.cs
+++ b/src/Miningcore/Api/Responses/GetPoolsResponse.cs
@@ -34,6 +34,9 @@ public class ApiCoinConfig
     public string Telegram { get; set; }
 
     [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string shareMultiplier { get; set; }
+
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string Github { get; set; }
 
     [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Miningcore/AutoMapperProfile.cs
+++ b/src/Miningcore/AutoMapperProfile.cs
@@ -48,6 +48,7 @@ public class AutoMapperProfile : Profile
             .ForMember(dest => dest.Twitter, opt => opt.MapFrom(src => src.Twitter))
             .ForMember(dest => dest.Discord, opt => opt.MapFrom(src => src.Discord))
             .ForMember(dest => dest.Telegram, opt => opt.MapFrom(src => src.Telegram))
+            .ForMember(dest => dest.shareMultiplier, opt => opt.MapFrom(src => src.shareMultiplier))
             .ForMember(dest => dest.Github, opt => opt.MapFrom(src => src.Github))
             .ForMember(dest => dest.Algorithm, opt => opt.MapFrom(src => src.GetAlgorithmName()));
 

--- a/src/Miningcore/Blockchain/Alephium/AlephiumPool.cs
+++ b/src/Miningcore/Blockchain/Alephium/AlephiumPool.cs
@@ -184,6 +184,7 @@ public class AlephiumPool : PoolBase
                     logger.Info(() => $"[{connection.ConnectionId}] Nicehash detected. Using API supplied difficulty of {nicehashDiff.Value}");
 
                     staticDiff = nicehashDiff;
+                    context.VarDiff = null; // disable vardiff for NiceHash
                 }
 
                 else
@@ -195,10 +196,10 @@ public class AlephiumPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting starting difficulty of {staticDiff.Value}");
             }
             
             // send intial job

--- a/src/Miningcore/Blockchain/Beam/BeamPool.cs
+++ b/src/Miningcore/Blockchain/Beam/BeamPool.cs
@@ -85,6 +85,8 @@ public class BeamPool : PoolBase
                     logger.Info(() => $"[{connection.ConnectionId}] Nicehash detected. Using API supplied difficulty of {nicehashDiff.Value}");
 
                     staticDiff = nicehashDiff;
+                    context.VarDiff = null; // disable vardiff for NiceHash
+
                 }
 
                 else
@@ -96,10 +98,10 @@ public class BeamPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting starting difficulty of {staticDiff.Value}");
             }
             
             // setup worker context

--- a/src/Miningcore/Blockchain/Bitcoin/BitcoinJobManagerBase.cs
+++ b/src/Miningcore/Blockchain/Bitcoin/BitcoinJobManagerBase.cs
@@ -402,8 +402,8 @@ public abstract class BitcoinJobManagerBase<TJob> : JobManagerBase<TJob>
         var response = await rpc.ExecuteAsync<NetworkInfo>(logger, BitcoinCommands.GetNetworkInfo, ct);
 
         // update stats
-        if(!string.IsNullOrEmpty(response.Response.Version))
-            BlockchainStats.NodeVersion = (string) response.Response?.Version;
+        if(!string.IsNullOrEmpty(response.Response?.Version))
+            BlockchainStats.NodeVersion = (string) response.Response.Version;
 
         return response.Error == null && response.Response?.Connections > 0;
     }

--- a/src/Miningcore/Blockchain/Bitcoin/BitcoinPool.cs
+++ b/src/Miningcore/Blockchain/Bitcoin/BitcoinPool.cs
@@ -125,10 +125,10 @@ public class BitcoinPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting starting difficulty of {staticDiff.Value}");
 
                 await connection.NotifyAsync(BitcoinStratumMethods.SetDifficulty, new object[] { context.Difficulty });
             }
@@ -307,10 +307,10 @@ public class BitcoinPool : PoolBase
 
         if(requestedDiff > poolEndpoint.Difficulty)
         {
-            context.VarDiff = null; // disable vardiff
+            // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
             context.SetDifficulty(requestedDiff);
 
-            logger.Info(() => $"[{connection.ConnectionId}] Difficulty set to {requestedDiff} as requested by miner. VarDiff now disabled.");
+            logger.Info(() => $"[{connection.ConnectionId}] Starting difficulty set to {requestedDiff} as requested by miner.");
 
             // enabled
             result[BitcoinStratumExtensions.MinimumDiff] = true;

--- a/src/Miningcore/Blockchain/Bitcoin/BitcoinPool.cs
+++ b/src/Miningcore/Blockchain/Bitcoin/BitcoinPool.cs
@@ -307,10 +307,10 @@ public class BitcoinPool : PoolBase
 
         if(requestedDiff > poolEndpoint.Difficulty)
         {
-            // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
+            context.VarDiff = null; // disable vardiff
             context.SetDifficulty(requestedDiff);
 
-            logger.Info(() => $"[{connection.ConnectionId}] Starting difficulty set to {requestedDiff} as requested by miner.");
+            logger.Info(() => $"[{connection.ConnectionId}] Difficulty set to {requestedDiff} as requested by miner. VarDiff now disabled.");
 
             // enabled
             result[BitcoinStratumExtensions.MinimumDiff] = true;

--- a/src/Miningcore/Blockchain/Conceal/ConcealPool.cs
+++ b/src/Miningcore/Blockchain/Conceal/ConcealPool.cs
@@ -102,6 +102,8 @@ public class ConcealPool : PoolBase
                     logger.Info(() => $"[{connection.ConnectionId}] Nicehash detected. Using API supplied difficulty of {nicehashDiff.Value}");
 
                     staticDiff = nicehashDiff;
+                    context.VarDiff = null; // disable vardiff for NiceHash
+
                 }
 
                 else
@@ -113,10 +115,10 @@ public class ConcealPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Static difficulty set to {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Starting difficulty set to {staticDiff.Value}");
             }
 
             // respond

--- a/src/Miningcore/Blockchain/Cryptonote/CryptonotePool.cs
+++ b/src/Miningcore/Blockchain/Cryptonote/CryptonotePool.cs
@@ -102,6 +102,7 @@ public class CryptonotePool : PoolBase
                     logger.Info(() => $"[{connection.ConnectionId}] Nicehash detected. Using API supplied difficulty of {nicehashDiff.Value}");
 
                     staticDiff = nicehashDiff;
+                    context.VarDiff = null; // disable vardiff for NiceHash                    
                 }
 
                 else
@@ -113,10 +114,10 @@ public class CryptonotePool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Static difficulty set to {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Starting difficulty set to {staticDiff.Value}");
             }
 
             // respond

--- a/src/Miningcore/Blockchain/Equihash/EquihashPool.cs
+++ b/src/Miningcore/Blockchain/Equihash/EquihashPool.cs
@@ -202,6 +202,7 @@ public class EquihashPool : PoolBase
                     logger.Info(() => $"[{connection.ConnectionId}] Nicehash detected. Using API supplied difficulty of {nicehashDiff.Value}");
 
                     staticDiff = nicehashDiff;
+                    context.VarDiff = null; // disable vardiff for NiceHash
                 }
 
                 else
@@ -213,10 +214,10 @@ public class EquihashPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting starting difficulty of {staticDiff.Value}");
 
                 await connection.NotifyAsync(BitcoinStratumMethods.SetDifficulty, new object[] { context.Difficulty });
             }

--- a/src/Miningcore/Blockchain/Ergo/ErgoPool.cs
+++ b/src/Miningcore/Blockchain/Ergo/ErgoPool.cs
@@ -117,6 +117,7 @@ public class ErgoPool : PoolBase
                     logger.Info(() => $"[{connection.ConnectionId}] Nicehash detected. Using API supplied difficulty of {nicehashDiff.Value}");
 
                     staticDiff = nicehashDiff;
+                    context.VarDiff = null; // disable vardiff for NiceHash
                 }
 
                 else
@@ -128,10 +129,10 @@ public class ErgoPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting starting difficulty of {staticDiff.Value}");
             }
 
             // send intial update

--- a/src/Miningcore/Blockchain/Ethereum/EthereumPool.cs
+++ b/src/Miningcore/Blockchain/Ethereum/EthereumPool.cs
@@ -129,6 +129,7 @@ public class EthereumPool : PoolBase
                     logger.Info(() => $"[{connection.ConnectionId}] Nicehash detected. Using API supplied difficulty of {nicehashDiff.Value}");
 
                     staticDiff = nicehashDiff;
+                    context.VarDiff = null; // disable vardiff for NiceHash
                 }
 
                 else
@@ -140,10 +141,10 @@ public class EthereumPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting starting difficulty of {staticDiff.Value}");
             }
 
             await connection.NotifyAsync(EthereumStratumMethods.SetDifficulty, new object[] { context.Difficulty });
@@ -305,6 +306,7 @@ public class EthereumPool : PoolBase
                     logger.Info(() => $"[{connection.ConnectionId}] Nicehash detected. Using API supplied difficulty of {nicehashDiff.Value}");
 
                     staticDiff = nicehashDiff;
+                    context.VarDiff = null; // disable vardiff for NiceHash
                 }
 
                 else
@@ -316,10 +318,10 @@ public class EthereumPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting starting difficulty of {staticDiff.Value}");
             }
 
             logger.Info(() => $"[{connection.ConnectionId}] Authorized worker {workerValue}");

--- a/src/Miningcore/Blockchain/Handshake/HandshakePool.cs
+++ b/src/Miningcore/Blockchain/Handshake/HandshakePool.cs
@@ -85,10 +85,10 @@ public class HandshakePool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting starting difficulty of {staticDiff.Value}");
 
                 await connection.NotifyAsync(BitcoinStratumMethods.SetDifficulty, new object[] { context.Difficulty });
             }

--- a/src/Miningcore/Blockchain/Kaspa/KaspaPool.cs
+++ b/src/Miningcore/Blockchain/Kaspa/KaspaPool.cs
@@ -173,7 +173,7 @@ public class KaspaPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
                 logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");

--- a/src/Miningcore/Blockchain/Kaspa/KaspaPool.cs
+++ b/src/Miningcore/Blockchain/Kaspa/KaspaPool.cs
@@ -162,6 +162,7 @@ public class KaspaPool : PoolBase
                     logger.Info(() => $"[{connection.ConnectionId}] Nicehash detected. Using API supplied difficulty of {nicehashDiff.Value}");
 
                     staticDiff = nicehashDiff;
+                    context.VarDiff = null; // disable vardiff for NiceHash
                 }
 
                 else
@@ -176,7 +177,7 @@ public class KaspaPool : PoolBase
                 // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting starting difficulty of {staticDiff.Value}");
             }
             
             // send intial job

--- a/src/Miningcore/Blockchain/Nexa/NexaPool.cs
+++ b/src/Miningcore/Blockchain/Nexa/NexaPool.cs
@@ -123,10 +123,10 @@ public class NexaPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting starting difficulty of {staticDiff.Value}");
 
                 await connection.NotifyAsync(BitcoinStratumMethods.SetDifficulty, new object[] { context.Difficulty });
             }
@@ -236,7 +236,7 @@ public class NexaPool : PoolBase
                 context.SetDifficulty(requestedDiff);
                 await connection.NotifyAsync(BitcoinStratumMethods.SetDifficulty, new object[] { context.Difficulty });
 
-                logger.Info(() => $"[{connection.ConnectionId}] Difficulty set to {requestedDiff} as requested by miner");
+                logger.Info(() => $"[{connection.ConnectionId}] Starting difficulty set to {requestedDiff} as requested by miner");
             }
         }
 

--- a/src/Miningcore/Blockchain/Progpow/ProgpowPool.cs
+++ b/src/Miningcore/Blockchain/Progpow/ProgpowPool.cs
@@ -137,10 +137,10 @@ public class ProgpowPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting starting difficulty of {staticDiff.Value}");
 
                 await connection.NotifyAsync(ProgpowStratumMethods.SetDifficulty, new object[] { createEncodeTarget(context.Difficulty) });
             }

--- a/src/Miningcore/Configuration/ClusterConfig.cs
+++ b/src/Miningcore/Configuration/ClusterConfig.cs
@@ -140,6 +140,11 @@ public abstract partial class CoinTemplate
     /// </summary>
     [JsonProperty(Order = -9)]
     public string Github { get; set; }
+
+    /// shareMultiplier Link
+    /// </summary>
+    [JsonProperty(Order = -9)]
+    public string shareMultiplier { get; set; }
     
     /// <summary>
     /// Arbitrary extension data

--- a/src/Miningcore/coins.json
+++ b/src/Miningcore/coins.json
@@ -157,22 +157,21 @@
         "explorerTxLink": "https://explorer.reaction.network/tx/{0}",
         "explorerAccountLink": "https://explorer.reaction.network/address/{0}"
     },
-	"regus": {
-        "name": "Regus",
-        "symbol": "REG",
-        "family": "progpow",
-        "progpower": "kawpow",
-        "website": "https://regus.app/",
-        "github": "https://github.com/RegusCrypto/Regus",
-        "market": "",
-        "twitter": "https://x.com/RegusCrypto",
-        "telegram": "",
-        "discord": "https://discord.gg/64JxxBGXHZ",
+    "raptoreum": {
+        "name": "Raptoreum",
+        "canonicalName": "Raptoreum",
+        "symbol": "RTM",
+        "family": "bitcoin",
+        "website": "https://raptoreum.com/",
+        "market": "https://coinmarketcap.com/currencies/raptoreum",
+        "twitter": "https://twitter.com/raptoreum",
+        "telegram": "https://t.me/raptoreum",
+        "discord": "https://discord.com/invite/2T8xG7e",
         "coinbaseHasher": {
             "hash": "sha256d"
         },
         "headerHasher": {
-            "hash": "sha256d"
+            "hash": "ghostrider"
         },
         "blockHasher": {
             "hash": "reverse",
@@ -182,10 +181,16 @@
                 }
             ]
         },
-        "shareMultiplier": 1,
-        "explorerBlockLink": "https://explorer.regus.app/block/$hash$",
-        "explorerTxLink": "https://explorer.regus.app/tx/{0}",
-        "explorerAccountLink": "https://explorer.regus.app/address/{0}"
+        "hasFounderFee": true,
+        "hasMasterNodes": true,
+        "hasSmartNodes": true,
+        "foundersRewardAddress": [
+            "RTtyQU6DoSuNWetT4WUem5qXP5jNYGpwat"
+        ],
+        "shareMultiplier": 65536,
+        "explorerBlockLink": "https://explorer.raptoreum.com/block-height/$height$",
+        "explorerTxLink": "https://explorer.raptoreum.com/tx/{0}",
+        "explorerAccountLink": "https://explorer.raptoreum.com/address/{0}"
     },
 	"xenixchain": {
         "name": "XenixChain",


### PR DESCRIPTION
This change aims to prevent cheaters from using ASICs on Karlsenhash and other unsupported Kaspa forks by replacing the fixed difficulty with a starting difficulty.

Previously, cheaters could exploit a very low difficulty to generate a high number of shares while finding almost no blocks. This behavior caused the effort required to find a block to increase significantly (in my case, by more than 2000%). Since we're using PPLNS (Pay Per Last N Shares), the bad actor would receive credit for these shares, effectively "stealing" rewards from other miners.

By switching to a starting difficulty, the system will adjust rapidly, even if a low difficulty is initially chosen.