### PR TITLE
Change Fixed Diff to Starting Diff

### DIFF
--- a/src/Miningcore/Blockchain/Alephium/AlephiumPool.cs
+++ b/src/Miningcore/Blockchain/Alephium/AlephiumPool.cs
@@ -195,10 +195,10 @@ public class AlephiumPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting initial difficulty of {staticDiff.Value} with VarDiff enabled");
             }
             
             // send intial job

--- a/src/Miningcore/Blockchain/Beam/BeamPool.cs
+++ b/src/Miningcore/Blockchain/Beam/BeamPool.cs
@@ -96,10 +96,10 @@ public class BeamPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting initial difficulty of {staticDiff.Value} with VarDiff enabled");
             }
             
             // setup worker context

--- a/src/Miningcore/Blockchain/Bitcoin/BitcoinPool.cs
+++ b/src/Miningcore/Blockchain/Bitcoin/BitcoinPool.cs
@@ -125,7 +125,7 @@ public class BitcoinPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
                 logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");

--- a/src/Miningcore/Blockchain/Bitcoin/BitcoinPool.cs
+++ b/src/Miningcore/Blockchain/Bitcoin/BitcoinPool.cs
@@ -128,7 +128,7 @@ public class BitcoinPool : PoolBase
                 // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting initial difficulty of {staticDiff.Value} with VarDiff enabled");
 
                 await connection.NotifyAsync(BitcoinStratumMethods.SetDifficulty, new object[] { context.Difficulty });
             }

--- a/src/Miningcore/Blockchain/Conceal/ConcealPool.cs
+++ b/src/Miningcore/Blockchain/Conceal/ConcealPool.cs
@@ -113,10 +113,10 @@ public class ConcealPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Static difficulty set to {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting initial difficulty of {staticDiff.Value} with VarDiff enabled");
             }
 
             // respond

--- a/src/Miningcore/Blockchain/Cryptonote/CryptonotePool.cs
+++ b/src/Miningcore/Blockchain/Cryptonote/CryptonotePool.cs
@@ -113,10 +113,10 @@ public class CryptonotePool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Static difficulty set to {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting initial difficulty of {staticDiff.Value} with VarDiff enabled");
             }
 
             // respond

--- a/src/Miningcore/Blockchain/Equihash/EquihashPool.cs
+++ b/src/Miningcore/Blockchain/Equihash/EquihashPool.cs
@@ -213,10 +213,10 @@ public class EquihashPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting initial difficulty of {staticDiff.Value} with VarDiff enabled");
 
                 await connection.NotifyAsync(BitcoinStratumMethods.SetDifficulty, new object[] { context.Difficulty });
             }

--- a/src/Miningcore/Blockchain/Ergo/ErgoPool.cs
+++ b/src/Miningcore/Blockchain/Ergo/ErgoPool.cs
@@ -128,10 +128,10 @@ public class ErgoPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting initial difficulty of {staticDiff.Value} with VarDiff enabled");
             }
 
             // send intial update

--- a/src/Miningcore/Blockchain/Ethereum/EthereumPool.cs
+++ b/src/Miningcore/Blockchain/Ethereum/EthereumPool.cs
@@ -140,10 +140,10 @@ public class EthereumPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting initial difficulty of {staticDiff.Value} with VarDiff enabled");
             }
 
             await connection.NotifyAsync(EthereumStratumMethods.SetDifficulty, new object[] { context.Difficulty });
@@ -316,10 +316,10 @@ public class EthereumPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting initial difficulty of {staticDiff.Value} with VarDiff enabled");
             }
 
             logger.Info(() => $"[{connection.ConnectionId}] Authorized worker {workerValue}");

--- a/src/Miningcore/Blockchain/Handshake/HandshakePool.cs
+++ b/src/Miningcore/Blockchain/Handshake/HandshakePool.cs
@@ -85,10 +85,10 @@ public class HandshakePool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting initial difficulty of {staticDiff.Value} with VarDiff enabled");
 
                 await connection.NotifyAsync(BitcoinStratumMethods.SetDifficulty, new object[] { context.Difficulty });
             }

--- a/src/Miningcore/Blockchain/Kaspa/KaspaPool.cs
+++ b/src/Miningcore/Blockchain/Kaspa/KaspaPool.cs
@@ -173,10 +173,10 @@ public class KaspaPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting initial difficulty of {staticDiff.Value} with VarDiff enabled");
             }
             
             // send intial job

--- a/src/Miningcore/Blockchain/Nexa/NexaPool.cs
+++ b/src/Miningcore/Blockchain/Nexa/NexaPool.cs
@@ -123,10 +123,10 @@ public class NexaPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting initial difficulty of {staticDiff.Value} with VarDiff enabled");
 
                 await connection.NotifyAsync(BitcoinStratumMethods.SetDifficulty, new object[] { context.Difficulty });
             }

--- a/src/Miningcore/Blockchain/Progpow/ProgpowPool.cs
+++ b/src/Miningcore/Blockchain/Progpow/ProgpowPool.cs
@@ -137,10 +137,10 @@ public class ProgpowPool : PoolBase
                (context.VarDiff != null && staticDiff.Value >= context.VarDiff.Config.MinDiff ||
                    context.VarDiff == null && staticDiff.Value > context.Difficulty))
             {
-                context.VarDiff = null; // disable vardiff
+                // context.VarDiff = null; // disable vardiff // Do not disable to change static diff to start diff.
                 context.SetDifficulty(staticDiff.Value);
 
-                logger.Info(() => $"[{connection.ConnectionId}] Setting static difficulty of {staticDiff.Value}");
+                logger.Info(() => $"[{connection.ConnectionId}] Setting initial difficulty of {staticDiff.Value} with VarDiff enabled");
 
                 await connection.NotifyAsync(ProgpowStratumMethods.SetDifficulty, new object[] { createEncodeTarget(context.Difficulty) });
             }


### PR DESCRIPTION
This change aims to prevent cheaters from using ASICs on Karlsenhash and other unsupported Kaspa forks by replacing the fixed difficulty with a starting difficulty.

Previously, cheaters could exploit a very low difficulty to generate a high number of shares while finding almost no blocks. This behavior caused the effort required to find a block to increase significantly (in my case, by more than 2000%). Since we're using PPLNS (Pay Per Last N Shares), the bad actor would receive credit for these shares, effectively "stealing" rewards from other miners.

By switching to a starting difficulty, the system will adjust rapidly, even if a low difficulty is initially chosen.